### PR TITLE
Deeplink enable connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project uses the Vault API. Visit https://developers.apideck.com/api-refere
 #### Step 1: Update your environment variables
 
 - Copy `.env.example` and create a `.env.local` file
-- Add your API key: `UNIFY_API_KEY=<you-api-key>`
+- Add your API key: `UNIFY_API_KEY=<your-api-key>`
 - Your env should also include `NEXT_PUBLIC_UNIFY_API_URL=https://unify.apideck.com`
 - Optional: Add a Busnag API key to activate [Bugsnag](https://www.bugsnag.com/) error monitoring.
 
@@ -34,7 +34,7 @@ This project uses the Vault API. Visit https://developers.apideck.com/api-refere
 - Run the development server with `yarn dev` or `npm run dev`
 - Visit `http://localhost:3003/` to see if it's running. You should see a message that your session is invalid.
 
-#### Step 4: Create a new session
+#### Step 3: Create a new session
 
 You have to make a POST request to the Vault API to create a valid session for a user. Hereafter referred to as the consumer ID.
 In order to make the request, you need your Apideck API Key, Application ID, and Consumer ID. The Consumer ID is stored inside Apideck Vault. This can be a user ID, account ID, device ID, or another entity that can be linked to integrations within your app.

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint-staged"
+      "pre-commit": "yarn lint-staged",
+      "pre-push": "jest --detectOpenHandles --colors --verbose --reporters=default --collectCoverage --no-cache --selectProjects=Unit"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "yarn lint-staged",
-      "pre-push": "jest --detectOpenHandles --colors --verbose --reporters=default --collectCoverage --no-cache --selectProjects=Unit"
+      "pre-push": "yarn test:unit"
     }
   },
   "lint-staged": {

--- a/src/components/ConfigurableResource/ResourceForm.tsx
+++ b/src/components/ConfigurableResource/ResourceForm.tsx
@@ -162,6 +162,7 @@ const ResourceForm = ({ loading, connection, resource, jwt, token }: IProps) => 
                                 onChange={handleChange}
                                 onBlur={handleBlur}
                                 className="max-w-sm"
+                                data-testid={id}
                               />
                             )}
                             {type === 'checkbox' && (

--- a/src/components/Connection/ConnectionForm.tsx
+++ b/src/components/Connection/ConnectionForm.tsx
@@ -155,19 +155,21 @@ const ConnectionForm = ({ connection, token, jwt, handleSubmit, handleDelete }: 
 
   return (
     <Fragment>
-      <Link href="/">
-        <button
-          className="inline-flex items-center self-start justify-start mb-4 text-sm leading-none text-gray-600 group hover:text-gray-800"
-          style={{ height: '24px' }}
-        >
-          <ArrowLeftIcon
-            className="mr-1 transition duration-150 ease-in-out"
-            color="currentColor"
-            size={16}
-          />
-          <span className="transition duration-150 ease-in-out">Integrations</span>
-        </button>
-      </Link>
+      {!router.query?.isolation && (
+        <Link href="/">
+          <button
+            className="inline-flex items-center self-start justify-start mb-4 text-sm leading-none text-gray-600 group hover:text-gray-800"
+            style={{ height: '24px' }}
+          >
+            <ArrowLeftIcon
+              className="mr-1 transition duration-150 ease-in-out"
+              color="currentColor"
+              size={16}
+            />
+            <span className="transition duration-150 ease-in-out">Integrations</span>
+          </button>
+        </Link>
+      )}
 
       <div className="border rounded-md">
         <div className="flex justify-between px-5 py-4 items-top">

--- a/src/components/Connection/ConnectionForm.tsx
+++ b/src/components/Connection/ConnectionForm.tsx
@@ -155,7 +155,7 @@ const ConnectionForm = ({ connection, token, jwt, handleSubmit, handleDelete }: 
 
   return (
     <Fragment>
-      {!router.query?.isolation && (
+      {!router?.query?.isolation && (
         <Link href="/">
           <button
             className="inline-flex items-center self-start justify-start mb-4 text-sm leading-none text-gray-600 group hover:text-gray-800"

--- a/src/pages/integrations/[unified-api]/[provider]/enable.tsx
+++ b/src/pages/integrations/[unified-api]/[provider]/enable.tsx
@@ -62,13 +62,11 @@ const AddResource = ({ jwt, token }: IProps) => {
       <div>
         <div className="inline-flex items-center self-start justify-start mb-4 text-sm leading-none">
           <div className="mr-1 bg-gray-200 rounded-md" style={{ height: '18px', width: '18px' }} />
-
           <div
             className="bg-gray-200 rounded-md skeleton-loading"
             style={{ height: '18px', width: '200px' }}
           />
         </div>
-
         <div className="mt-4 border rounded-md">
           <div className="flex justify-between py-4 pl-5 align-center">
             <div className="inline-flex">
@@ -78,13 +76,11 @@ const AddResource = ({ jwt, token }: IProps) => {
                 style={{ height: '18px', width: '240px' }}
               ></div>
             </div>
-
             <div
               className="m-2 mr-5 bg-gray-200 rounded"
               style={{ height: '30px', width: '80px' }}
             />
           </div>
-
           <div className="px-5 py-6 border-t">
             <div className="ml-14">
               <div

--- a/src/pages/integrations/[unified-api]/[provider]/enable.tsx
+++ b/src/pages/integrations/[unified-api]/[provider]/enable.tsx
@@ -54,7 +54,7 @@ const AddResource = ({ jwt, token }: IProps) => {
         })
     }
 
-    if (query.jwt && token.applicationId && token.consumerId) enableConnection()
+    if (jwt && token.applicationId && token.consumerId) enableConnection()
   }, [jwt, push, query, token.applicationId, token.consumerId])
 
   if (isLoading) {

--- a/src/pages/integrations/[unified-api]/[provider]/enable.tsx
+++ b/src/pages/integrations/[unified-api]/[provider]/enable.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react'
+import { JWTSession } from 'types/JWTSession'
+import { applySession } from 'next-session'
+import camelcaseKeys from 'camelcase-keys'
+import client from 'lib/axios'
+import { decode } from 'jsonwebtoken'
+import { options } from 'utils/sessionOptions'
+import { useRouter } from 'next/router'
+import { AxiosResponse } from 'axios'
+
+interface IProps {
+  jwt: string
+  token: JWTSession
+}
+
+const AddResource = ({ jwt, token }: IProps) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+  const { query, push } = useRouter()
+
+  useEffect(() => {
+    const enableConnection = () => {
+      setIsLoading(true)
+      setError(null)
+      client
+        .patch(
+          `/vault/connections/${query['unified-api']}/${query.provider}`,
+          {
+            unifiedApi: query['unified-api'],
+            serviceId: query.provider,
+            settings: {},
+            enabled: true
+          },
+          {
+            headers: {
+              Authorization: `Bearer ${jwt}`,
+              'X-APIDECK-APP-ID': token.applicationId,
+              'X-APIDECK-CONSUMER-ID': token.consumerId
+            }
+          }
+        )
+        .then((response: AxiosResponse<{ enabled: boolean; error: string }>) => {
+          if (response.data?.enabled) {
+            push(`/integrations/${query['unified-api']}/${query.provider}?isolation=true`)
+          } else {
+            setError(response.data?.error)
+          }
+        })
+        .catch((error) => {
+          setError(error?.message || error)
+        })
+        .finally(() => {
+          setIsLoading(false)
+        })
+    }
+
+    if (query.jwt && token.applicationId && token.consumerId) enableConnection()
+  }, [jwt, push, query, token.applicationId, token.consumerId])
+
+  if (isLoading) {
+    return (
+      <div>
+        <div className="inline-flex items-center self-start justify-start mb-4 text-sm leading-none">
+          <div className="mr-1 bg-gray-200 rounded-md" style={{ height: '18px', width: '18px' }} />
+
+          <div
+            className="bg-gray-200 rounded-md skeleton-loading"
+            style={{ height: '18px', width: '200px' }}
+          />
+        </div>
+
+        <div className="mt-4 border rounded-md">
+          <div className="flex justify-between py-4 pl-5 align-center">
+            <div className="inline-flex">
+              <div className="w-8 h-8 mt-1 bg-gray-200 rounded-full skeleton-loading"></div>
+              <div
+                className="mt-3 ml-6 bg-gray-200 rounded skeleton-loading"
+                style={{ height: '18px', width: '240px' }}
+              ></div>
+            </div>
+
+            <div
+              className="m-2 mr-5 bg-gray-200 rounded"
+              style={{ height: '30px', width: '80px' }}
+            />
+          </div>
+
+          <div className="px-5 py-6 border-t">
+            <div className="ml-14">
+              <div
+                className="mt-1 bg-gray-200 rounded skeleton-loading"
+                style={{ height: '18px', width: '240px' }}
+              ></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!isLoading && error) return <h1>{error}</h1>
+  return <div />
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function getServerSideProps({ req, res, query }: any): Promise<any> {
+  await applySession(req, res, options)
+
+  const { jwt } = query
+  if (jwt) {
+    req.session.jwt = jwt
+    const decoded = decode(jwt) as JWTSession
+    if (decoded) req.session.token = camelcaseKeys(decoded)
+  }
+
+  return {
+    props: {
+      jwt: req.session.jwt || '',
+      token: req.session.token || {}
+    }
+  }
+}
+
+export default AddResource


### PR DESCRIPTION
When navigating directly to `/integrations/<unified-api>/<service-id>/enable?jwt=<token>` it will apply the session for the application and make a request to update the connection and set `enabled` to `true`. After that, it will redirect to the connection page (for example `/integration/lead/salesforce`) with the `isolation=true` param which results in hiding the breadcrumb links.

@Gdewilde could you test it out and see if it works as you expected? So the whole flow with coming from the ecosystem. Please note that you should add the token you receive from the session call to the URL as a query param (`?jwt=token`) 

If there is anything missing please let me know.