### PR TITLE
Add custom logo to theming options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You should now be able to make requests to the Vault API.
 
 #### Theming
 
-By default, the Vault will match the colors of your Apideck ecosystem. If you haven't made any changes in the theming settings of your ecosystem, you could also overwrite the default settings inside `src/config/defaults`.
+By default, the Vault will match the colors of your Apideck ecosystem. If you haven't made any changes in the theming settings of your ecosystem, you could also overwrite the default settings inside `src/config/defaults` or send a `theme` object in the body of the `sessions` request.
 
 ## Hosted Vault
 

--- a/src/components/Connections/ConnectionCard.tsx
+++ b/src/components/Connections/ConnectionCard.tsx
@@ -3,9 +3,9 @@ import { FaCircle, FaExclamationTriangle } from 'react-icons/fa'
 import { IConnection } from 'types/Connection'
 import Link from 'next/link'
 import MenuRightIcon from 'mdi-react/MenuRightIcon'
+import classNames from 'classnames'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import { isConnected } from 'utils'
-import classNames from 'classnames'
 
 interface IProps {
   connection: IConnection
@@ -22,7 +22,12 @@ const ConnectionCard = ({ connection }: IProps) => {
         data-testid={'connection-link'}
       >
         <div className="flex items-center">
-          <img className="mr-5" style={{ width: '36px', height: '36px' }} src={icon} alt={name} />
+          <img
+            className="mr-5 rounded"
+            style={{ width: '36px', height: '36px' }}
+            src={icon}
+            alt={name}
+          />
           <div className="text-left">
             <div className="font-medium text-md spec-connection-name">{name}</div>
             <div className="text-gray-600" style={{ fontSize: '0.8125rem' }}>

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -23,6 +23,7 @@ const Layout: React.FC<IProps> = ({
   const {
     vault_name: vaultName,
     favicon,
+    logo,
     primary_color: primaryColor,
     terms_url: termsUrl,
     privacy_url: privacyUrl
@@ -45,7 +46,17 @@ const Layout: React.FC<IProps> = ({
         style={{ minWidth: '400px', maxWidth: '480px' }}
       >
         <div>
-          <div className="mb-10 text-2xl font-medium">{vaultName || 'Apideck Vault'}</div>
+          {logo && (
+            <div className="flex flex-col justify-end" style={{ height: 120, marginTop: -120 }}>
+              <img
+                className="mb-4 rounded"
+                src={logo}
+                alt={vaultName || 'Apideck Vault'}
+                style={{ maxWidth: 60 }}
+              />
+            </div>
+          )}
+          <div className="mb-12 text-2xl font-medium">{vaultName || 'Apideck Vault'}</div>
           <a
             className="inline-flex items-center text-sm text-gray-500 group hover:text-gray-800"
             href={redirectUri ? redirectUri : 'https://app.apideck.com'}
@@ -76,7 +87,7 @@ const Layout: React.FC<IProps> = ({
               )}
               <div>
                 {accountName && (
-                  <div className="text-xs text-gray-500 uppercase mb-2">{accountName}</div>
+                  <div className="mb-2 text-xs text-gray-500 uppercase">{accountName}</div>
                 )}
                 {userName && <div className="text-sm leading-none">{userName}</div>}
               </div>

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -11,6 +11,7 @@ export const defaults = {
     sidepanel_background_color: '#16263e',
     sidepanel_text_color: '#FFFFFF',
     terms_url: 'https://www.termsfeed.com/terms-conditions/957c85c1b089ae9e3219c83eff65377e',
-    vault_name: 'Vault Sample Project'
+    vault_name: 'Vault Sample Project',
+    logo: ''
   }
 }

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -6,6 +6,7 @@ export interface ThemeContextType {
   primary_color: string
   terms_url: string
   privacy_url: string
+  logo: string
 }
 
 export const ThemeContext = createContext({})


### PR DESCRIPTION
Providing the `logo` property will show the logo above the vault name. If nothing is provided we don't show a logo and the layout will stay the same.

For example:
```
       theme: {
          vault_name: 'SalesFlare Vault',
          logo:
            'https://res.cloudinary.com/apideck/image/upload/v1529455988/catalog/salesflare/icon128x128.png'
        }
```

Will result in:

![CleanShot 2021-03-31 at 13 28 41](https://user-images.githubusercontent.com/17762366/113139143-029aa080-9227-11eb-9284-472e9701e8f8.png)
