### PR TITLE
fix: OAuth confirm grant handoff (vault leg)

### DIFF
--- a/__tests__/unit/pages/oauth/callback.test.tsx
+++ b/__tests__/unit/pages/oauth/callback.test.tsx
@@ -1,5 +1,10 @@
-import { render } from '../../../testUtils/testing-utils'
+import { render, screen, waitFor } from '../../../testUtils/testing-utils'
 import CallbackPage, { getServerSideProps } from 'pages/oauth/callback'
+import client from 'lib/axios'
+
+jest.mock('lib/axios')
+
+const GRANT_KEY = 'apideck_oauth_grant_test-service'
 
 describe('OAuth Callback Page', () => {
   const closeSpy = jest.fn()
@@ -7,6 +12,7 @@ describe('OAuth Callback Page', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    sessionStorage.clear()
     window.close = closeSpy
   })
 
@@ -140,7 +146,7 @@ describe('OAuth Callback Page', () => {
       expect(closeSpy).toHaveBeenCalled()
     })
 
-    it('does not throw when CSRF params present in hash but no opener', () => {
+    it('renders a loud error (not a silent close) when CSRF params present in hash but no opener', () => {
       window.location.hash =
         '#nonce=test-nonce&confirm_token=test-token&service_id=test-service'
       Object.defineProperty(window, 'opener', {
@@ -149,9 +155,168 @@ describe('OAuth Callback Page', () => {
         configurable: true
       })
 
-      expect(() => {
-        render(<CallbackPage hasError={false} query={{}} />)
-      }).not.toThrow()
+      render(<CallbackPage hasError={false} query={{}} />)
+
+      expect(screen.getByText(/could not be completed in this window/i)).toBeDefined()
+      expect(postMessageSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('grant self-confirm', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'opener', {
+        value: { postMessage: postMessageSpy },
+        writable: true,
+        configurable: true
+      })
+    })
+
+    it('when a grant is stored and hash has confirm_token/service_id/unified_api: POSTs { confirm_token, grant } unauthenticated and closes', async () => {
+      sessionStorage.setItem(GRANT_KEY, 'grant-abc')
+      // No nonce in the hash — the grant is the auth, so self-confirm is nonce-independent.
+      window.location.hash =
+        '#confirm_token=test-token&service_id=test-service&unified_api=crm'
+      ;(client.post as jest.Mock).mockResolvedValue({
+        data: { status_code: 200, status: 'OK', data: { confirmed: true } }
+      })
+
+      render(<CallbackPage hasError={false} query={{}} />)
+
+      await waitFor(() => expect(closeSpy).toHaveBeenCalled())
+      expect(client.post).toHaveBeenCalledWith('/vault/connections/crm/test-service/confirm', {
+        confirm_token: 'test-token',
+        grant: 'grant-abc'
+      })
+      expect(sessionStorage.getItem(GRANT_KEY)).toBeNull()
+    })
+
+    it('removes the grant from sessionStorage even before the POST resolves', () => {
+      sessionStorage.setItem(GRANT_KEY, 'grant-abc')
+      window.location.hash =
+        '#confirm_token=test-token&service_id=test-service&unified_api=crm'
+      // Never-resolving POST: the grant must already be cleared synchronously.
+      ;(client.post as jest.Mock).mockReturnValue(new Promise(() => undefined))
+
+      render(<CallbackPage hasError={false} query={{}} />)
+
+      expect(sessionStorage.getItem(GRANT_KEY)).toBeNull()
+    })
+
+    it('does NOT post oauth_complete to opener when the grant self-confirm succeeds', async () => {
+      sessionStorage.setItem(GRANT_KEY, 'grant-abc')
+      // nonce + opener present so the legacy relay WOULD fire if the grant path didn't win.
+      window.location.hash =
+        '#nonce=test-nonce&confirm_token=test-token&service_id=test-service&unified_api=crm'
+      ;(client.post as jest.Mock).mockResolvedValue({
+        data: { status_code: 200, status: 'OK', data: { confirmed: true } }
+      })
+
+      render(<CallbackPage hasError={false} query={{}} />)
+
+      await waitFor(() => expect(closeSpy).toHaveBeenCalled())
+      expect(postMessageSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'oauth_complete' }),
+        '*'
+      )
+    })
+
+    it('falls back to legacy oauth_complete relay when self-confirm POST rejects', async () => {
+      sessionStorage.setItem(GRANT_KEY, 'grant-abc')
+      window.location.hash =
+        '#nonce=test-nonce&confirm_token=test-token&service_id=test-service&unified_api=crm'
+      ;(client.post as jest.Mock).mockRejectedValue(new Error('grant expired'))
+
+      render(<CallbackPage hasError={false} query={{}} />)
+
+      await waitFor(() => expect(client.post).toHaveBeenCalled())
+      await waitFor(() =>
+        expect(postMessageSpy).toHaveBeenCalledWith(
+          {
+            type: 'oauth_complete',
+            nonce: 'test-nonce',
+            confirmToken: 'test-token',
+            serviceId: 'test-service',
+            success: true
+          },
+          '*'
+        )
+      )
+      expect(closeSpy).toHaveBeenCalled()
+    })
+
+    it('falls back to legacy oauth_complete relay when no grant is stored', () => {
+      // No grant seeded.
+      window.location.hash =
+        '#nonce=test-nonce&confirm_token=test-token&service_id=test-service&unified_api=crm'
+
+      render(<CallbackPage hasError={false} query={{}} />)
+
+      expect(client.post).not.toHaveBeenCalled()
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        {
+          type: 'oauth_complete',
+          nonce: 'test-nonce',
+          confirmToken: 'test-token',
+          serviceId: 'test-service',
+          success: true
+        },
+        '*'
+      )
+      expect(closeSpy).toHaveBeenCalled()
+    })
+
+    it('falls back to legacy relay when grant is stored but unified_api is absent from the hash', () => {
+      sessionStorage.setItem(GRANT_KEY, 'grant-abc')
+      // unify has not shipped unified_api yet; nonce + opener present for rung 2.
+      window.location.hash =
+        '#nonce=test-nonce&confirm_token=test-token&service_id=test-service'
+
+      render(<CallbackPage hasError={false} query={{}} />)
+
+      expect(client.post).not.toHaveBeenCalled()
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        {
+          type: 'oauth_complete',
+          nonce: 'test-nonce',
+          confirmToken: 'test-token',
+          serviceId: 'test-service',
+          success: true
+        },
+        '*'
+      )
+    })
+  })
+
+  describe('null-opener success-shaped strand', () => {
+    it('renders a loud error (not a silent close) when hash is success-shaped, no grant, and no opener', () => {
+      window.location.hash =
+        '#nonce=test-nonce&confirm_token=test-token&service_id=test-service'
+      Object.defineProperty(window, 'opener', {
+        value: null,
+        writable: true,
+        configurable: true
+      })
+
+      render(<CallbackPage hasError={false} query={{}} />)
+
+      expect(screen.getByText(/could not be completed in this window/i)).toBeDefined()
+      expect(closeSpy).not.toHaveBeenCalled()
+    })
+
+    it('closes silently (no relay, no loud error) when hash has confirm_token + service_id but NO nonce and no grant, opener present', () => {
+      // Legacy relay gate still requires nonce and is NOT widened.
+      window.location.hash = '#confirm_token=test-token&service_id=test-service'
+      Object.defineProperty(window, 'opener', {
+        value: { postMessage: postMessageSpy },
+        writable: true,
+        configurable: true
+      })
+
+      render(<CallbackPage hasError={false} query={{}} />)
+
+      expect(closeSpy).toHaveBeenCalled()
+      expect(postMessageSpy).not.toHaveBeenCalled()
+      expect(screen.queryByText(/could not be completed in this window/i)).toBeNull()
     })
   })
 })

--- a/__tests__/unit/pages/oauth/launch.test.tsx
+++ b/__tests__/unit/pages/oauth/launch.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen, act, cleanup } from '../../../testUtils/testing-utils'
+import LaunchPage from 'pages/oauth/launch'
+import {
+  OAUTH_LAUNCH_READY,
+  OAUTH_LAUNCH_START,
+  READY_REPEAT_INTERVAL_MS,
+  GRANT_KEY_PREFIX
+} from 'utils/oauthGrantHandoff'
+
+describe('OAuth Launch Page', () => {
+  const postMessageSpy = jest.fn()
+  const closeSpy = jest.fn()
+  let assignSpy: jest.Mock
+  const originalLocation = window.location
+
+  const setSearch = (search: string) => {
+    delete (window as any).location
+    window.location = {
+      search,
+      hash: '',
+      href: `http://localhost/oauth/launch${search}`,
+      assign: assignSpy
+    } as any
+  }
+
+  const setOpener = (opener: unknown) => {
+    Object.defineProperty(window, 'opener', {
+      value: opener,
+      writable: true,
+      configurable: true
+    })
+  }
+
+  // Dispatch a message event with a caller-controlled `source` (jsdom's
+  // MessageEvent constructor rejects plain objects as `source`, so we override
+  // the getter after construction).
+  const dispatchMessage = (data: unknown, source: unknown) => {
+    const event = new MessageEvent('message', { data: data as any })
+    Object.defineProperty(event, 'source', { value: source, configurable: true })
+    act(() => {
+      window.dispatchEvent(event)
+    })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+    sessionStorage.clear()
+    assignSpy = jest.fn()
+    window.close = closeSpy
+    setSearch('?service_id=test-service')
+    setOpener({ postMessage: postMessageSpy })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    setOpener(null)
+    window.location = originalLocation
+  })
+
+  it('posts oauth_launch_ready to window.opener on mount when opener and storage are available', () => {
+    render(<LaunchPage />)
+
+    expect(postMessageSpy).toHaveBeenCalledWith({ type: OAUTH_LAUNCH_READY }, '*')
+  })
+
+  it('re-posts oauth_launch_ready every READY_REPEAT_INTERVAL_MS until answered', () => {
+    jest.useFakeTimers()
+
+    render(<LaunchPage />)
+    const initialCalls = postMessageSpy.mock.calls.length
+
+    act(() => {
+      jest.advanceTimersByTime(READY_REPEAT_INTERVAL_MS)
+    })
+    const afterOne = postMessageSpy.mock.calls.length
+
+    act(() => {
+      jest.advanceTimersByTime(READY_REPEAT_INTERVAL_MS)
+    })
+    const afterTwo = postMessageSpy.mock.calls.length
+
+    expect(afterOne).toBeGreaterThan(initialCalls)
+    expect(afterTwo).toBeGreaterThan(afterOne)
+  })
+
+  it('renders a loud error and does NOT post ready when window.opener is null', () => {
+    setOpener(null)
+
+    render(<LaunchPage />)
+
+    expect(screen.getByText(/can't complete the connection/i)).toBeDefined()
+    expect(screen.getByRole('button', { name: /close window/i })).toBeDefined()
+    expect(postMessageSpy).not.toHaveBeenCalled()
+    expect(assignSpy).not.toHaveBeenCalled()
+  })
+
+  it('renders a loud error and does NOT post ready when the sessionStorage probe fails', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage disabled')
+    })
+
+    render(<LaunchPage />)
+
+    expect(screen.getByText(/can't complete the connection/i)).toBeDefined()
+    expect(postMessageSpy).not.toHaveBeenCalled()
+    expect(assignSpy).not.toHaveBeenCalled()
+  })
+
+  it('on oauth_launch_start from window.opener: stores the grant under apideck_oauth_grant_{serviceId} and navigates via window.location.assign(authorizeUrl)', () => {
+    render(<LaunchPage />)
+
+    dispatchMessage(
+      {
+        type: OAUTH_LAUNCH_START,
+        grant: 'grant-xyz',
+        authorizeUrl: 'https://provider.example/authorize?x=1'
+      },
+      window.opener
+    )
+
+    expect(sessionStorage.getItem(`${GRANT_KEY_PREFIX}test-service`)).toBe('grant-xyz')
+    expect(assignSpy).toHaveBeenCalledWith('https://provider.example/authorize?x=1')
+  })
+
+  it('stops re-posting oauth_launch_ready after a valid oauth_launch_start', () => {
+    jest.useFakeTimers()
+
+    render(<LaunchPage />)
+
+    dispatchMessage(
+      {
+        type: OAUTH_LAUNCH_START,
+        grant: 'grant-xyz',
+        authorizeUrl: 'https://provider.example/authorize'
+      },
+      window.opener
+    )
+
+    const callsAfterStart = postMessageSpy.mock.calls.length
+
+    act(() => {
+      jest.advanceTimersByTime(READY_REPEAT_INTERVAL_MS * 4)
+    })
+
+    expect(postMessageSpy.mock.calls.length).toBe(callsAfterStart)
+  })
+
+  it('ignores oauth_launch_start whose event.source is not window.opener', () => {
+    render(<LaunchPage />)
+
+    dispatchMessage(
+      {
+        type: OAUTH_LAUNCH_START,
+        grant: 'grant-xyz',
+        authorizeUrl: 'https://provider.example/authorize'
+      },
+      { postMessage: jest.fn() } // a different frame, not the opener
+    )
+
+    expect(sessionStorage.getItem(`${GRANT_KEY_PREFIX}test-service`)).toBeNull()
+    expect(assignSpy).not.toHaveBeenCalled()
+  })
+
+  it('ignores messages whose data.type is not oauth_launch_start', () => {
+    render(<LaunchPage />)
+
+    dispatchMessage(
+      { type: 'some_other_message', grant: 'grant-xyz', authorizeUrl: 'https://x' },
+      window.opener
+    )
+
+    expect(sessionStorage.getItem(`${GRANT_KEY_PREFIX}test-service`)).toBeNull()
+    expect(assignSpy).not.toHaveBeenCalled()
+  })
+
+  it('clears the ready interval and removes the message listener on unmount', () => {
+    jest.useFakeTimers()
+
+    render(<LaunchPage />)
+    cleanup()
+    jest.clearAllMocks()
+
+    act(() => {
+      jest.advanceTimersByTime(READY_REPEAT_INTERVAL_MS * 4)
+    })
+
+    // Interval cleared: no further ready posts after unmount.
+    expect(postMessageSpy).not.toHaveBeenCalled()
+
+    // Listener removed: a post-unmount start message is ignored.
+    dispatchMessage(
+      {
+        type: OAUTH_LAUNCH_START,
+        grant: 'grant-xyz',
+        authorizeUrl: 'https://provider.example/authorize'
+      },
+      window.opener
+    )
+    expect(sessionStorage.getItem(`${GRANT_KEY_PREFIX}test-service`)).toBeNull()
+    expect(assignSpy).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/unit/utils/oauthGrantHandoff.test.ts
+++ b/__tests__/unit/utils/oauthGrantHandoff.test.ts
@@ -1,0 +1,115 @@
+import client from 'lib/axios'
+import {
+  storeGrant,
+  readAndClearGrant,
+  probeSessionStorage,
+  confirmWithGrant
+} from 'utils/oauthGrantHandoff'
+
+jest.mock('lib/axios')
+
+describe('oauthGrantHandoff', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+    sessionStorage.clear()
+  })
+
+  describe('storeGrant', () => {
+    it('stores the grant in sessionStorage under apideck_oauth_grant_{serviceId}', () => {
+      storeGrant('test-service', 'grant-abc')
+
+      expect(sessionStorage.getItem('apideck_oauth_grant_test-service')).toBe('grant-abc')
+    })
+
+    it('uses the serviceId in the storage key', () => {
+      storeGrant('salesforce', 'grant-1')
+      storeGrant('hubspot', 'grant-2')
+
+      expect(sessionStorage.getItem('apideck_oauth_grant_salesforce')).toBe('grant-1')
+      expect(sessionStorage.getItem('apideck_oauth_grant_hubspot')).toBe('grant-2')
+    })
+  })
+
+  describe('readAndClearGrant', () => {
+    it('returns the stored grant for the serviceId', () => {
+      sessionStorage.setItem('apideck_oauth_grant_test-service', 'grant-abc')
+
+      expect(readAndClearGrant('test-service')).toBe('grant-abc')
+    })
+
+    it('removes the grant from sessionStorage after reading', () => {
+      sessionStorage.setItem('apideck_oauth_grant_test-service', 'grant-abc')
+
+      readAndClearGrant('test-service')
+
+      expect(sessionStorage.getItem('apideck_oauth_grant_test-service')).toBeNull()
+    })
+
+    it('returns null when no grant is stored for the serviceId', () => {
+      expect(readAndClearGrant('test-service')).toBeNull()
+    })
+  })
+
+  describe('probeSessionStorage', () => {
+    it('returns true when a write-read-remove round-trip succeeds', () => {
+      expect(probeSessionStorage()).toBe(true)
+    })
+
+    it('returns false when sessionStorage.setItem throws', () => {
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('storage disabled')
+      })
+
+      expect(probeSessionStorage()).toBe(false)
+    })
+
+    it('leaves no probe key behind on success', () => {
+      probeSessionStorage()
+
+      expect(sessionStorage.length).toBe(0)
+    })
+  })
+
+  describe('confirmWithGrant', () => {
+    const params = {
+      unifiedApi: 'crm',
+      serviceId: 'salesforce',
+      confirmToken: 'confirm-tok-123',
+      grant: 'grant-abc'
+    }
+
+    it('POSTs { confirm_token, grant } to /vault/connections/{unifiedApi}/{serviceId}/confirm with no auth headers', async () => {
+      ;(client.post as jest.Mock).mockResolvedValue({
+        data: { status_code: 200, status: 'OK', data: { confirmed: true } }
+      })
+
+      await confirmWithGrant(params)
+
+      expect(client.post).toHaveBeenCalledWith('/vault/connections/crm/salesforce/confirm', {
+        confirm_token: 'confirm-tok-123',
+        grant: 'grant-abc'
+      })
+
+      // No auth headers: the grant is the auth. Assert no third (config) argument
+      // carrying Authorization / X-APIDECK-* headers was passed.
+      const call = (client.post as jest.Mock).mock.calls[0]
+      expect(call[2]).toBeUndefined()
+    })
+
+    it('returns the response data on success', async () => {
+      const responseData = { status_code: 200, status: 'OK', data: { confirmed: true } }
+      ;(client.post as jest.Mock).mockResolvedValue({ data: responseData })
+
+      const result = await confirmWithGrant(params)
+
+      expect(result).toEqual(responseData)
+    })
+
+    it('propagates errors from the API call', async () => {
+      ;(client.post as jest.Mock).mockRejectedValue(new Error('grant expired'))
+
+      await expect(confirmWithGrant(params)).rejects.toThrow('grant expired')
+    })
+  })
+})

--- a/src/pages/oauth/callback.tsx
+++ b/src/pages/oauth/callback.tsx
@@ -1,54 +1,112 @@
 import { OAuthError, createOAuthErrorFromQuery } from 'utils'
+import { confirmWithGrant, readAndClearGrant } from 'utils/oauthGrantHandoff'
 import { useEffect, useState } from 'react'
 
 import { Button } from '@apideck/components'
 import { OAuthErrorAlert } from 'components'
 
+/**
+ * OAuth popup callback. Fallback ladder (highest rung wins):
+ *   1. Grant self-confirm (new): if a single-use grant is stored for this
+ *      service_id and the hash carries confirm_token + service_id + unified_api,
+ *      redeem `{ confirm_token, grant }` UNAUTHENTICATED in-tab (the grant is the
+ *      auth — nonce-independent) and close. On any failure, fall through.
+ *   2. Legacy opener relay (unchanged): post `oauth_complete` to window.opener
+ *      when nonce + confirm_token + service_id + opener are present, then close.
+ *   3. Error relay / in-page server error (unchanged).
+ *   4. Null-opener strand: a success-shaped hash (nonce + confirm_token +
+ *      service_id) with no opener now renders a loud error instead of a silent
+ *      close; any other hash still closes silently.
+ *
+ * Deployment order: unify (grant mint + `/confirm` accepting `{ confirm_token,
+ * grant }` + `unified_api` in the callback fragment) → this leg → vault-core
+ * widget. Until unify ships, the grant/`unified_api` are absent and this page
+ * degrades to the legacy opener relay.
+ */
 const CallbackPage = ({ hasError, query }: { hasError: boolean; query: any }) => {
   const [oauthError, setOAuthError] = useState<OAuthError | null>(null)
+  const [loudError, setLoudError] = useState(false)
 
   useEffect(() => {
-    // Success params now arrive in URL fragment (not query) after unify Fix 3
+    // Success params arrive in the URL fragment (not query) after unify Fix 3.
     const hashParams = new URLSearchParams(window.location.hash.slice(1))
     const nonce = hashParams.get('nonce')
     const confirm_token = hashParams.get('confirm_token')
     const service_id = hashParams.get('service_id')
+    const unified_api = hashParams.get('unified_api')
 
-    if (nonce && confirm_token && service_id && window.opener) {
-      window.opener.postMessage(
-        {
-          type: 'oauth_complete',
-          nonce,
-          confirmToken: confirm_token,
-          serviceId: service_id,
-          success: true
-        },
-        '*'
-      )
-      window.close()
-    } else if (query?.error_type && window.opener) {
-      // Error params remain in query — not moved to fragment
-      window.opener.postMessage(
-        {
-          type: 'oauth_error',
-          error: query.error_type,
-          errorDescription: query.error_message,
-          serviceId: query.service_id
-        },
-        '*'
-      )
-      window.close()
-    } else if (hasError) {
-      setOAuthError(createOAuthErrorFromQuery(query))
-    } else {
-      window.close()
+    const confirmOAuth = async () => {
+      // Rung 1: grant self-confirm (nonce-independent — the grant is the auth).
+      // readAndClearGrant is single-use: the grant is consumed even if the guard
+      // below is false (e.g. unify has not yet shipped unified_api).
+      const grant = service_id ? readAndClearGrant(service_id) : null
+
+      if (grant && confirm_token && service_id && unified_api) {
+        try {
+          await confirmWithGrant({
+            unifiedApi: unified_api,
+            serviceId: service_id,
+            confirmToken: confirm_token,
+            grant
+          })
+          window.close()
+          return
+        } catch {
+          // Grant redemption failed (expired/used/invalid, or unify not ready):
+          // fall through to the legacy fallback ladder below.
+        }
+      }
+
+      // Fallback ladder (also reached when no grant attempt was made).
+      if (nonce && confirm_token && service_id && window.opener) {
+        // Rung 2: legacy opener relay (gate unchanged — still requires nonce).
+        window.opener.postMessage(
+          {
+            type: 'oauth_complete',
+            nonce,
+            confirmToken: confirm_token,
+            serviceId: service_id,
+            success: true
+          },
+          '*'
+        )
+        window.close()
+      } else if (query?.error_type && window.opener) {
+        // Error params remain in query — not moved to fragment.
+        window.opener.postMessage(
+          {
+            type: 'oauth_error',
+            error: query.error_type,
+            errorDescription: query.error_message,
+            serviceId: query.service_id
+          },
+          '*'
+        )
+        window.close()
+      } else if (hasError) {
+        setOAuthError(createOAuthErrorFromQuery(query))
+      } else if (nonce && confirm_token && service_id) {
+        // Success-shaped hash but no opener (and no successful grant self-confirm):
+        // loud error instead of the old silent close.
+        setLoudError(true)
+      } else {
+        window.close()
+      }
     }
+
+    confirmOAuth()
   }, [hasError, query])
 
   return (
     <div className="flex flex-col justify-between">
       {oauthError ? <OAuthErrorAlert error={oauthError} /> : null}
-      {hasError ? (
+      {loudError ? (
+        <p className="mb-4">
+          The authorization could not be completed in this window. Please close this window and try
+          again.
+        </p>
+      ) : null}
+      {hasError || loudError ? (
         <Button
           text="Close window"
           size="larger"

--- a/src/pages/oauth/launch.tsx
+++ b/src/pages/oauth/launch.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react'
+
+import { Button } from '@apideck/components'
+import { LaunchStartMessage } from 'types/OAuthGrantHandoff'
+import {
+  OAUTH_LAUNCH_READY,
+  OAUTH_LAUNCH_START,
+  READY_REPEAT_INTERVAL_MS,
+  probeSessionStorage,
+  storeGrant
+} from 'utils/oauthGrantHandoff'
+
+/**
+ * COOP-free popup landing page for the forward OAuth grant handoff (vault leg).
+ *
+ * The widget opens this page in the popup while the `window.opener` link is still
+ * alive, hands over a single-use grant + the authorize URL via `postMessage`, and
+ * this page stashes the grant in tab `sessionStorage` before navigating to the
+ * provider. After the provider round-trip, `oauth/callback` self-confirms in-tab
+ * with `{ confirm_token, grant }` — no backwards `postMessage` needed.
+ *
+ * Anti-phishing: if there is no opener or `sessionStorage` is unavailable, the page
+ * renders a loud error BEFORE posting ready or navigating (pre-consent).
+ *
+ * The grant never appears in any URL — it travels only over the live opener
+ * handshake and then only through `sessionStorage`. Source identity is checked
+ * (`event.source === window.opener`); there is no `event.origin` allowlist.
+ */
+const LaunchPage = () => {
+  const [launchError, setLaunchError] = useState(false)
+
+  useEffect(() => {
+    // Anti-phishing gate (pre-consent): refuse loudly without an opener or storage.
+    if (!window.opener) {
+      setLaunchError(true)
+      return
+    }
+    if (!probeSessionStorage()) {
+      setLaunchError(true)
+      return
+    }
+
+    const serviceId = new URLSearchParams(window.location.search).get('service_id')
+
+    const postReady = () => window.opener.postMessage({ type: OAUTH_LAUNCH_READY }, '*')
+    postReady()
+    const readyTimer = setInterval(postReady, READY_REPEAT_INTERVAL_MS)
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.source !== window.opener) return
+      if (event.data?.type !== OAUTH_LAUNCH_START) return
+
+      const { grant, authorizeUrl } = event.data as LaunchStartMessage
+      if (serviceId) {
+        storeGrant(serviceId, grant)
+      }
+      clearInterval(readyTimer)
+      window.removeEventListener('message', handleMessage)
+      window.location.assign(authorizeUrl)
+    }
+
+    window.addEventListener('message', handleMessage)
+
+    return () => {
+      clearInterval(readyTimer)
+      window.removeEventListener('message', handleMessage)
+    }
+  }, [])
+
+  if (launchError) {
+    return (
+      <div className="flex flex-col justify-between">
+        <p className="mb-4">
+          This window can&apos;t complete the connection. Please close it and try again.
+        </p>
+        <Button
+          text="Close window"
+          size="larger"
+          className="w-full"
+          onClick={() => window.close()}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col justify-between">
+      <p>Connecting…</p>
+    </div>
+  )
+}
+
+export default LaunchPage

--- a/src/pages/oauth/launch.tsx
+++ b/src/pages/oauth/launch.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { Button } from '@apideck/components'
-import { LaunchStartMessage } from 'types/OAuthGrantHandoff'
+import { LaunchReadyMessage, LaunchStartMessage } from 'types/OAuthGrantHandoff'
 import {
   OAUTH_LAUNCH_READY,
   OAUTH_LAUNCH_START,
@@ -42,7 +42,8 @@ const LaunchPage = () => {
 
     const serviceId = new URLSearchParams(window.location.search).get('service_id')
 
-    const postReady = () => window.opener.postMessage({ type: OAUTH_LAUNCH_READY }, '*')
+    const readyMessage: LaunchReadyMessage = { type: OAUTH_LAUNCH_READY }
+    const postReady = () => window.opener.postMessage(readyMessage, '*')
     postReady()
     const readyTimer = setInterval(postReady, READY_REPEAT_INTERVAL_MS)
 

--- a/src/pages/oauth/launch.tsx
+++ b/src/pages/oauth/launch.tsx
@@ -24,7 +24,7 @@ import {
  *
  * The grant never appears in any URL — it travels only over the live opener
  * handshake and then only through `sessionStorage`. Source identity is checked
- * (`event.source === window.opener`); there is no `event.origin` allowlist.
+ * (message source must be the opener); there is no origin allowlist.
  */
 const LaunchPage = () => {
   const [launchError, setLaunchError] = useState(false)

--- a/src/types/OAuthGrantHandoff.ts
+++ b/src/types/OAuthGrantHandoff.ts
@@ -1,0 +1,31 @@
+import { IConfirmResponse } from 'types/OAuthCsrf'
+
+/**
+ * Wire contract for the OAuth grant-handoff flow (vault leg).
+ *
+ * This file mirrors the vault-core wire contract, which is the source of truth
+ * for the message shapes (vault-core `src/types/OAuthGrantHandoff.ts`). Keep the
+ * `oauth_launch_ready` / `oauth_launch_start` shapes in sync with that file.
+ *
+ * Invariants:
+ * - The grant is single-use, session-bound, and NEVER carried in any URL.
+ * - The grant travels only over the live opener `postMessage` handshake into the
+ *   launch page and then only through tab `sessionStorage`.
+ * - The grant confirm is unauthenticated (the grant is the auth).
+ */
+
+// Launch page → widget: the launch page has loaded and is ready to receive the grant.
+export interface LaunchReadyMessage {
+  type: 'oauth_launch_ready'
+}
+
+// Widget → launch page: hand over the grant and the authorize URL to continue with.
+export interface LaunchStartMessage {
+  type: 'oauth_launch_start'
+  grant: string
+  authorizeUrl: string
+}
+
+// Response shape of the unauthenticated grant confirm. Reuses the legacy confirm
+// response shape (`types/OAuthCsrf.ts`) to avoid drift.
+export type IGrantConfirmResponse = IConfirmResponse

--- a/src/utils/oauthGrantHandoff.ts
+++ b/src/utils/oauthGrantHandoff.ts
@@ -1,0 +1,63 @@
+import client from 'lib/axios'
+import { IGrantConfirmResponse } from 'types/OAuthGrantHandoff'
+
+/**
+ * Grant-handoff util (vault leg of the forward OAuth confirm handoff).
+ *
+ * Invariants:
+ * - The grant is NEVER carried in any URL. It travels only over the live opener
+ *   `postMessage` handshake into the launch page and then only through tab
+ *   `sessionStorage`.
+ * - The grant is single-use: `readAndClearGrant` reads and removes in one step.
+ * - `confirmWithGrant` is UNAUTHENTICATED — it sends no `Authorization` /
+ *   `X-APIDECK-APP-ID` / `X-APIDECK-CONSUMER-ID` headers (the grant is the auth).
+ *   Contrast `callConfirmEndpoint` (`utils/oauthCsrf.ts`).
+ * - Only `pages/oauth/launch.tsx` (writer) and `pages/oauth/callback.tsx`
+ *   (reader/confirmer) consume this module.
+ */
+
+export const GRANT_KEY_PREFIX = 'apideck_oauth_grant_'
+export const OAUTH_LAUNCH_READY = 'oauth_launch_ready'
+export const OAUTH_LAUNCH_START = 'oauth_launch_start'
+export const READY_REPEAT_INTERVAL_MS = 250
+
+const PROBE_KEY = 'apideck_oauth_storage_probe'
+
+export function storeGrant(serviceId: string, grant: string): void {
+  sessionStorage.setItem(`${GRANT_KEY_PREFIX}${serviceId}`, grant)
+}
+
+export function readAndClearGrant(serviceId: string): string | null {
+  const key = `${GRANT_KEY_PREFIX}${serviceId}`
+  const grant = sessionStorage.getItem(key)
+  sessionStorage.removeItem(key)
+  return grant
+}
+
+export function probeSessionStorage(): boolean {
+  try {
+    const probe = `${PROBE_KEY}_${GRANT_KEY_PREFIX}`
+    sessionStorage.setItem(PROBE_KEY, probe)
+    const readBack = sessionStorage.getItem(PROBE_KEY)
+    sessionStorage.removeItem(PROBE_KEY)
+    return readBack === probe
+  } catch {
+    return false
+  }
+}
+
+export async function confirmWithGrant(params: {
+  unifiedApi: string
+  serviceId: string
+  confirmToken: string
+  grant: string
+}): Promise<IGrantConfirmResponse> {
+  const { unifiedApi, serviceId, confirmToken, grant } = params
+
+  const { data } = await client.post<IGrantConfirmResponse>(
+    `/vault/connections/${unifiedApi}/${serviceId}/confirm`,
+    { confirm_token: confirmToken, grant }
+  )
+
+  return data
+}


### PR DESCRIPTION
## Summary

- Adds the **popup (vault) leg of the forward OAuth confirm grant handoff**: a COOP-free `GET /oauth/launch` landing page that receives a single-use **grant** from the widget over the still-alive `window.opener` link *at open time*, stores it in tab `sessionStorage`, and navigates to the provider's authorize URL.
- Makes `oauth/callback` **self-confirm in-tab** with `{ confirm_token, grant }` (unauthenticated — the grant is the auth) after the provider round-trip, so no backwards `postMessage` to `window.opener` is needed. This fixes embedded connections sticking at `pending_confirmation` when Cross-Origin-Opener-Policy (COOP) severs `window.opener` during the provider's navigation chain.
- Keeps the legacy `oauth_complete` opener relay fully armed as the fallback rung with its gate **unchanged**, so the change is additive and safe for older widgets and for a unify rollback.

**Related Issue**: [GH-9546](https://github.com/apideck-io/unify/issues/9546)

## What changed

### New popup landing page (`/oauth/launch`)
A bare, COOP-free page (modeled on `callback.tsx`, no `Layout`) that the widget opens while the `window.opener` link is still alive:

- **Anti-phishing gate (pre-consent)**: if `window.opener` is null **or** a `sessionStorage` write-read probe fails, it renders a loud error and refuses **before** posting ready or navigating.
- Otherwise it posts `oauth_launch_ready` to the opener every 250 ms until answered.
- On an `oauth_launch_start` message **from the opener** (`event.source === window.opener`), it stores the grant under `apideck_oauth_grant_${serviceId}`, stops repeating, removes the listener, and `window.location.assign(authorizeUrl)`.
- **Source-identity check only** — no `event.origin` check or origin allowlist (honors the recorded "do not touch origin" constraint).

### Callback in-tab grant self-confirm (`/oauth/callback`)
A new grant self-confirm rung is added **ahead of** the legacy relay, with the legacy ladder preserved byte-for-byte:

1. **Grant self-confirm (new, nonce-independent)**: read + clear the grant for the hash `service_id`; if a grant is present with `confirm_token` + `service_id` + `unified_api`, POST `{ confirm_token, grant }` unauthenticated and close. On any failure it falls through to the legacy ladder (the grant attempt `return`s on success; its `catch` falls into the same synchronous fallback ladder the no-grant path reaches).
2. **Legacy opener relay (unchanged)**: `oauth_complete` when `nonce && confirm_token && service_id && window.opener` — gate **not** widened, still requires `nonce`.
3. **Error relay / in-page server error (unchanged)**.
4. **Null-opener strand (the one legacy behavior change)**: a success-shaped hash (`nonce && confirm_token && service_id`) with no opener now renders a **loud in-page error** instead of the old silent `window.close()`. Any hash lacking `nonce` still closes silently.

### New utility module (`src/utils/oauthGrantHandoff.ts`)
Pure, parameter-object functions next to `oauthCsrf.ts` (no React context):
- `storeGrant(serviceId, grant)` / `readAndClearGrant(serviceId)` — sessionStorage-backed, **single-use** (read + remove in one step).
- `probeSessionStorage()` — write-read-remove round-trip; `false` on mismatch or any thrown error.
- `confirmWithGrant({ unifiedApi, serviceId, confirmToken, grant })` — POSTs `{ confirm_token, grant }` to `/vault/connections/{unifiedApi}/{serviceId}/confirm` with **no** `Authorization` / `X-APIDECK-APP-ID` / `X-APIDECK-CONSUMER-ID` headers (contrast the JWT-authenticated `callConfirmEndpoint`).

### New wire-protocol types (`src/types/OAuthGrantHandoff.ts`)
`LaunchReadyMessage` / `LaunchStartMessage` (mirrors vault-core's exported contract; vault-core is the source of truth) and `IGrantConfirmResponse` (aliases the existing `IConfirmResponse` to avoid drift).

### Security invariants (grep-verified in CI-style checks)
- The grant **never appears in any URL** — it travels only over the live opener `postMessage` handshake and then only through tab `sessionStorage`. The launch URL carries only the non-secret `service_id`.
- **COOP is not introduced** anywhere (`next.config.js` unchanged).
- **No `event.origin` check / origin allowlist** is added.

## How has this been tested?

**80 tests passing across 10 test suites** (up from 47/7). TDD red-green per component — every new branch/timeout/error/fallback has a named test.

- **`oauthGrantHandoff.test.ts`** (11 tests): `storeGrant` (key format / no collision), `readAndClearGrant` (read / single-use removal / missing), `probeSessionStorage` (success / throw / no residue), `confirmWithGrant` (unauthenticated POST shape / returns data / propagates error).
- **`launch.test.tsx`** (9 tests): ready post + 250 ms repeat; loud error on null opener; loud error on storage-probe failure; grant store + `assign(authorizeUrl)` on valid start; repeat stops after start; foreign-`event.source` ignored; wrong `data.type` ignored; interval + listener cleaned up on unmount.
- **`callback.test.tsx`** (17 tests, extended): grant self-confirm POST + close; single-use grant removal before POST resolves; no double-confirm when self-confirm succeeds; fallback to legacy relay on POST reject; fallback when no grant; fallback when `unified_api` absent; loud error on success-shaped/no-grant/no-opener; **silent close preserved for a no-`nonce` hash (legacy gate not widened)**; plus all preserved legacy behaviors.

Verification results:
- [x] `yarn test` — 80 tests passing (10 suites)
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] Grant never URL-carried — `grep -rn "grant" src/ | grep -iE "searchParams|\?grant|&grant"` returns empty
- [x] COOP never introduced — `grep -rin "opener-policy|embedder-policy|content-security-policy" next.config.js src/` returns empty
- [x] No `event.origin` check — `grep -rn "event.origin|\.origin ===" src/pages/oauth/ src/utils/oauthGrantHandoff.ts` returns empty
- [ ] Manual `dev` matrix: (a) launch page with a stub opener answering `oauth_launch_start` → grant stored, tab navigates; (b) callback with seeded grant + `unified_api` hash → self-confirm POST fires; (c) callback with no grant but an opener → legacy `oauth_complete` still posts; (d) callback success-shaped, no grant, no opener → loud error
- [ ] Manual: opening `/oauth/launch?service_id=x` directly (no opener) shows the loud error and never navigates
- [ ] Cross-browser spot check (Chrome, Firefox, Safari) once the vault-core widget + unify legs exist

## Deployment & rollout notes

**Deployment order is load-bearing**: unify (grant mint + `/confirm` accepting `{ confirm_token, grant }` + `unified_api` in the callback fragment) → **this vault leg** → vault-core widget release.

This leg is **safe to ship early**: with no vault-core widget opening the launch URL, `/oauth/launch` is simply never reached, and the callback self-confirm degrades to the legacy opener relay whenever a grant or `unified_api` is absent. A unify rollback degrades the callback to the legacy relay per attempt. No stored client state persists across sessions (the grant is single-use and session-scoped).

**Sole legacy-path behavior change**: the null-opener success-shaped strand (silent close → loud error).

## Changelog

Added a COOP-free `/oauth/launch` popup landing page and in-tab grant self-confirm in `/oauth/callback` so embedded OAuth connections no longer stick at `pending_confirmation` when COOP severs `window.opener`. The legacy opener relay remains as a fallback.
